### PR TITLE
Feature/adding content loading placeholder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "node-fetch": "^2.6.1",
         "rxfire": "^4.0.0",
         "rxjs": "^6.6.7",
-        "sirv-cli": "^1.0.0"
+        "sirv-cli": "^1.0.0",
+        "svelte-content-loader": "^1.1.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -1828,6 +1829,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/svelte-content-loader": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svelte-content-loader/-/svelte-content-loader-1.1.3.tgz",
+      "integrity": "sha512-hXkwyAXiZ+2uNvWUHPj9U7M+8PGqgZVFNxyOHjLUF1ng4W9P9+9wlyT/bNx5BjuqoJsfjv1IZP1/5T1LfRKtYA=="
+    },
     "node_modules/svelte-preprocess": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.7.4.tgz",
@@ -3508,6 +3514,11 @@
           }
         }
       }
+    },
+    "svelte-content-loader": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svelte-content-loader/-/svelte-content-loader-1.1.3.tgz",
+      "integrity": "sha512-hXkwyAXiZ+2uNvWUHPj9U7M+8PGqgZVFNxyOHjLUF1ng4W9P9+9wlyT/bNx5BjuqoJsfjv1IZP1/5T1LfRKtYA=="
     },
     "svelte-preprocess": {
       "version": "4.7.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node-fetch": "^2.6.1",
     "rxfire": "^4.0.0",
     "rxjs": "^6.6.7",
-    "sirv-cli": "^1.0.0"
+    "sirv-cli": "^1.0.0",
+    "svelte-content-loader": "^1.1.3"
   }
 }

--- a/public/global.css
+++ b/public/global.css
@@ -23,16 +23,21 @@ DECALRING GLOBAL VARIABLES
 https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties */
 :root {
     --app-height: 100%;
-
-    /* Main App Colors, */
+    /* 
+    Main App Colors, */
     --primary: #F5620F;
     --secondary: #1B1B1B;
     --light: #FFFFFF;
     --tertiary: #00FFD1;
-
-    /* Dark Theme, */
+    /* 
+    Dark Theme, */
     --dark: #292929;
     --background-surface: #121212;
+    /* 
+    breakpoints */
+    --mobile: 375;
+    --tablet: 767;
+    --destop: 1440;
 }
 
 

--- a/src/components/_MobileBetarenaWidget.svelte
+++ b/src/components/_MobileBetarenaWidget.svelte
@@ -15,7 +15,15 @@
         LanguageParam,
         LanguageTranslation,
         FinalLanguageResponse
-    } from "../models/firebase-real-db-interface"; 
+    } from '../models/firebase-real-db-interface'
+
+    import type {
+        ContentLoaderProps
+    } from '../models/content-loader-interface'
+
+    import { onMount } from 'svelte';
+
+    import ContentLoader from 'svelte-content-loader';
 
     /**
      * Function / Method
@@ -40,9 +48,35 @@
         
         return finalLanguageResponse
     }
-
-
     let promise = widgetInit()
+
+    /**
+     *  Function / Method;
+     * ~~~~~~~~~~~~~~~~~~~
+     * Description:
+     * Deliberately delays the display of the
+     * widget component for the users to show the
+     * PlaceHolder loading;
+     * 
+     * REMOVE THIS FOR PRODUCTION; 
+     * AS IT DELAYS ACCESS TO THE WEBSITE;
+    */
+    let show: boolean = false
+    onMount (async() => {
+        setTimeout(() => {
+            show = true
+        }, 3500);
+    });
+
+    /**
+     * Decalring the ContentLoaderProps
+     * values through the interface 
+    */
+    let contentLoaderProps: ContentLoaderProps = {
+        width: `100%`,
+        height: `100%`,
+        primaryColor: '#f9f9f9'
+    }
 </script>
 
 <!-- 
@@ -69,6 +103,17 @@ MOBILE FIRST -->
         width: inherit;
         height: calc(100vw / 3.98936170213);
         object-fit: cover;
+    }
+    #ad_widget_betarena-loading {
+        width: calc(100vw / 1.09329446064);
+        height: calc(100vw / 0.95663265306);
+        /* 
+        constant-properties */
+        background: #FFFFFF;
+        box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.08);
+        border-radius: 12px;
+        overflow: hidden;
+        margin: auto;
     }
     /*
     ~~~~~~~~~~~~~~~~~~~~
@@ -117,105 +162,115 @@ MOBILE FIRST -->
 -->
 
 {#await promise}
-    <p>... Loading Widget ...</p>
+    <div id='ad_widget_betarena-loading'>
+        <ContentLoader {...contentLoaderProps} />
+    </div>
     
 {:then data}
-    <div id='ad_widget_betarena'>
-        <!--
-        matchbetting-logo -->
-        <img 
-            src={data.logo}
-            alt=""
-            id='booker-logo'
-        />
-        <div id='further-quick-info'>
-            <!-- 
-            further-analytics-info -->
-            <div class='row' style='margin-bottom: calc(100vw / 18.75); height: calc(100vw / 8.33333333333);'>
-                <div class='info-box'>
-                    <p class='large' style='color: var(--primary);'>{ data.avg_payout } %</p>
-                    <p class='medium'>{data.lang.avg_payout}</p>
-                </div>
-                <div class='info-box'>
-                    <p class='large' style='color: #68D77A'>{ data.payout_speed }</p>
-                    <p class='medium'>{data.lang.payout_speed}</p>
-                </div>
-                {#if data.apps_support}
+    <!-- 
+    simple further buffer to see the content loader-transition -->
+    {#if !show}
+        <div id='ad_widget_betarena-loading'>
+            <ContentLoader {...contentLoaderProps} />
+        </div>
+    {:else}
+        <div id='ad_widget_betarena'>
+            <!--
+            matchbetting-logo -->
+            <img 
+                src={data.logo}
+                alt=""
+                id='booker-logo'
+            />
+            <div id='further-quick-info'>
+                <!-- 
+                further-analytics-info -->
+                <div class='row' style='margin-bottom: calc(100vw / 18.75); height: calc(100vw / 8.33333333333);'>
                     <div class='info-box'>
-                        <div class='row'>
-                            <img 
-                            src='./static/BetArena - Working/icon/android.svg'
-                            alt=''
-                                class='device-support'
-                            />
-                            <img 
-                                src='./static/BetArena - Working/icon/apple.svg'
-                                alt=''
-                                class='device-support'
-                            />
-                            <img 
-                                src='./static/BetArena - Working/icon/chrome-colored.svg'
-                                alt=''
-                                class='device-support'
-                            />
-                        </div>
-                        <p class='medium'>{data.lang.apps_support}</p>
+                        <p class='large' style='color: var(--primary);'>{ data.avg_payout } %</p>
+                        <p class='medium'>{data.lang.avg_payout}</p>
                     </div>
-                {/if}
+                    <div class='info-box'>
+                        <p class='large' style='color: #68D77A'>{ data.payout_speed }</p>
+                        <p class='medium'>{data.lang.payout_speed}</p>
+                    </div>
+                    {#if data.apps_support}
+                        <div class='info-box'>
+                            <div class='row'>
+                                <img 
+                                src='./static/BetArena - Working/icon/android.svg'
+                                alt=''
+                                    class='device-support'
+                                />
+                                <img 
+                                    src='./static/BetArena - Working/icon/apple.svg'
+                                    alt=''
+                                    class='device-support'
+                                />
+                                <img 
+                                    src='./static/BetArena - Working/icon/chrome-colored.svg'
+                                    alt=''
+                                    class='device-support'
+                                />
+                            </div>
+                            <p class='medium'>{data.lang.apps_support}</p>
+                        </div>
+                    {/if}
+                </div>
+                <!-- 
+                validation-row-further-info -->
+                <div class='row'>
+                    {#if data.cashout}
+                        <div class='row'>
+                            <img
+                                src='./static/BetArena - Working/icon/􀁣.svg'
+                                alt=''
+                                class='checkmark'
+                            />
+                            <p class='small'>{ data.lang.cashout }</p>
+                        </div>
+                    {/if}
+                    {#if data.live_stream}
+                        <div class='row'>
+                            <img
+                                src='./static/BetArena - Working/icon/􀁣.svg'
+                                alt=''
+                                class='checkmark'
+                            />
+                            <p class='small'>{ data.lang.live_stream }</p>
+                        </div>
+                    {/if}
+                    {#if data.bet_builder}
+                        <div class='row'>
+                            <img
+                                src='./static/BetArena - Working/icon/􀁣.svg'
+                                alt=''
+                                class='checkmark'
+                            />
+                            <p class='small'>{ data.lang.bet_builder }</p>
+                        </div>
+                    {/if}
+                </div>
             </div>
             <!-- 
-            validation-row-further-info -->
-            <div class='row'>
-                {#if data.cashout}
-                    <div class='row'>
-                        <img
-                            src='./static/BetArena - Working/icon/􀁣.svg'
-                            alt=''
-                            class='checkmark'
-                        />
-                        <p class='small'>{ data.lang.cashout }</p>
-                    </div>
-                {/if}
-                {#if data.live_stream}
-                    <div class='row'>
-                        <img
-                            src='./static/BetArena - Working/icon/􀁣.svg'
-                            alt=''
-                            class='checkmark'
-                        />
-                        <p class='small'>{ data.lang.live_stream }</p>
-                    </div>
-                {/if}
-                {#if data.bet_builder}
-                    <div class='row'>
-                        <img
-                            src='./static/BetArena - Working/icon/􀁣.svg'
-                            alt=''
-                            class='checkmark'
-                        />
-                        <p class='small'>{ data.lang.bet_builder }</p>
-                    </div>
-                {/if}
+            promotion-info-container -->
+            <div id='promotion-info-box'>
+                <p class='small' style='margin-bottom: 12px;'>
+                    { data.lang.disclaimer }
+                </p>
+                <button class='btn-primary' style='margin-bottom: 20px;'>
+                    <p class='medium'>
+                        Get 500$ bonus
+                    </p>
+                </button>
+                <a href="/">
+                    <p class='medium' style='color: var(--primary); font-weight: 500;'>
+                        { data.lang.read_full_review } >
+                    </p>
+                </a>
             </div>
         </div>
-        <!-- 
-        promotion-info-container -->
-        <div id='promotion-info-box'>
-            <p class='small' style='margin-bottom: 12px;'>
-                { data.lang.disclaimer }
-            </p>
-            <button class='btn-primary' style='margin-bottom: 20px;'>
-                <p class='medium'>
-                    Get 500$ bonus
-                </p>
-            </button>
-            <a href="/">
-                <p class='medium' style='color: var(--primary); font-weight: 500;'>
-                    { data.lang.read_full_review } >
-                </p>
-            </a>
-        </div>
-    </div>
+    {/if}
     
 {:catch error}
     <p style="color: red">{error.message}</p>

--- a/src/components/_TabletPlusBetarenaWidget.svelte
+++ b/src/components/_TabletPlusBetarenaWidget.svelte
@@ -15,10 +15,19 @@
         LanguageParam,
         LanguageTranslation,
         FinalLanguageResponse
-    } from "../models/firebase-real-db-interface"; 
+    } from "../models/firebase-real-db-interface"
+
+    import type {
+        ContentLoaderProps
+    } from '../models/content-loader-interface'
+
+    import { onMount } from 'svelte';
+
+    import ContentLoader from 'svelte-content-loader';
 
     /**
      * Function / Method
+     * ~~~~~~~~~~~~~~~~~~~
      * Description:
      * Intializer of the Widget Function
      * 
@@ -37,12 +46,37 @@
             lang: db_real_data_translation
         }
         // console.info('final-response', finalLanguageResponse)
-        
         return finalLanguageResponse
     }
-
-
     let promise = widgetInit()
+
+    /**
+     *  Function / Method;
+     * ~~~~~~~~~~~~~~~~~~~
+     * Description:
+     * Deliberately delays the display of the
+     * widget component for the users to show the
+     * PlaceHolder loading;
+     * 
+     * REMOVE THIS FOR PRODUCTION; 
+     * AS IT DELAYS ACCESS TO THE WEBSITE;
+    */
+    let show: boolean = false
+    onMount (async() => {
+        setTimeout(() => {
+            show = true
+        }, 3500);
+    });
+
+    /**
+     * Decalring the ContentLoaderProps
+     * values through the interface 
+    */
+    let contentLoaderProps: ContentLoaderProps = {
+        width: `100%`,
+        height: `100%`,
+        primaryColor: '#f9f9f9'
+    }
 </script>
 
 <!-- 
@@ -203,6 +237,8 @@ TABLED & DESKTOP FIRST -->
     }
 </style>
 
+<!-- calc(100vw / (var(--mobile) / 6.2)); -->
+
 <!-- 
 ~~~~~~~~~~~~
 	COMPONENT HTML
@@ -210,122 +246,132 @@ TABLED & DESKTOP FIRST -->
 -->
 
 {#await promise}
-    <p>... Loading Widget ...</p>
+    <div id='ad_widget_betarena'>
+        <ContentLoader {...contentLoaderProps} />
+    </div>
     
 {:then data}
-    <div id='ad_widget_betarena'>
-        <!--
-        matchbetting-logo -->
-        <img 
-            src={data.logo}
-            alt=""
-            id='booker-logo'
-        />
-        <div id='desktop-container'>
-            <!-- 
-            further-info -->
-            <div id='further-quick-info'>
+    <!-- 
+    simple further buffer to see the content loader-transition -->
+    {#if !show}
+        <div id='ad_widget_betarena'>
+            <ContentLoader {...contentLoaderProps} />
+        </div>
+    {:else}
+        <div id='ad_widget_betarena'>
+            <!--
+            matchbetting-logo -->
+            <img 
+                src={data.logo}
+                alt=""
+                id='booker-logo'
+            />
+            <div id='desktop-container'>
                 <!-- 
-                further-analytics-info -->
-                <div class='row'>
-                    <div class='info-box'>
-                        <p class='large' style='color: var(--primary);'>{data.avg_payout} %</p>
-                        <p class='medium'>{data.lang.avg_payout}</p>
-                    </div>
-                    <div class='info-box'>
-                        <p class='large' style='color: #68D77A'>{data.payout_speed}</p>
-                        <p class='medium'>{data.lang.payout_speed}</p>
-                    </div>
-                    {#if data.apps_support}
+                further-info -->
+                <div id='further-quick-info'>
+                    <!-- 
+                    further-analytics-info -->
+                    <div class='row'>
                         <div class='info-box'>
-                            <div class='row'>
-                                <img 
-                                src='./static/BetArena - Working/icon/android.svg'
-                                alt=''
-                                    class='device-support'
-                                />
-                                <img 
-                                    src='./static/BetArena - Working/icon/apple.svg'
+                            <p class='large' style='color: var(--primary);'>{data.avg_payout} %</p>
+                            <p class='medium'>{data.lang.avg_payout}</p>
+                        </div>
+                        <div class='info-box'>
+                            <p class='large' style='color: #68D77A'>{data.payout_speed}</p>
+                            <p class='medium'>{data.lang.payout_speed}</p>
+                        </div>
+                        {#if data.apps_support}
+                            <div class='info-box'>
+                                <div class='row'>
+                                    <img 
+                                    src='./static/BetArena - Working/icon/android.svg'
                                     alt=''
-                                    class='device-support'
-                                />
-                                <img 
-                                    src='./static/BetArena - Working/icon/chrome-colored.svg'
-                                    alt=''
-                                    class='device-support'
-                                />
+                                        class='device-support'
+                                    />
+                                    <img 
+                                        src='./static/BetArena - Working/icon/apple.svg'
+                                        alt=''
+                                        class='device-support'
+                                    />
+                                    <img 
+                                        src='./static/BetArena - Working/icon/chrome-colored.svg'
+                                        alt=''
+                                        class='device-support'
+                                    />
+                                </div>
+                                <p class='medium'>{data.lang.apps_support}</p>
                             </div>
-                            <p class='medium'>{data.lang.apps_support}</p>
-                        </div>
-                    {/if}
-                </div>
-                <!-- 
-                CTA-read-more -->
-                <a href="/">
-                    <p class='small' style='color: var(--primary); font-weight: 500;'>
-                        { data.lang.read_full_review } >
-                    </p>
-                </a>
-            </div>
-            <!-- 
-            promotion-info-container -->
-            <div id='promotion-info-box'>
-                <!-- 
-                validation-row-further-info -->
-                <div class='column' style='margin-right: calc(100vw / 12.5901639344);'>
-                    {#if data.cashout}
-                        <div class='row check-box'>
-                            <img
-                                src='./static/BetArena - Working/icon/􀁣.svg'
-                                alt=''
-                                class='checkmark'
-                            />
-                            <p class='small' style='white-space: nowrap;'>{ data.lang.cashout }</p>
-                        </div>
-                    {:else}
-                        <div/>
-                    {/if}
-                    {#if data.live_stream}
-                        <div class='row check-box'>
-                            <img
-                                src='./static/BetArena - Working/icon/􀁣.svg'
-                                alt=''
-                                class='checkmark'
-                            />
-                            <p class='small' style='white-space: nowrap;'>{ data.lang.live_stream }</p>
-                        </div>
-                    {:else}
-                        <div/>
-                    {/if}
-                    {#if data.bet_builder}
-                        <div class='row check-box'>
-                            <img
-                                src='./static/BetArena - Working/icon/􀁣.svg'
-                                alt=''
-                                class='checkmark'
-                            />
-                            <p class='small' style='white-space: nowrap;'>{ data.lang.bet_builder }</p>
-                        </div>
-                    {:else}
-                        <div/>
-                    {/if}
-                </div>
-                <!-- 
-                disclaimer-info-&-button -->
-                <div class='row'>
-                    <p class='small' style='margin-right: calc(100vw / 48); text-align: end;'>
-                        { data.lang.disclaimer }
-                    </p>
-                    <button class='btn-primary'>
-                        <p class='medium' style='white-space: nowrap;'>
-                            Get 500$ bonus
+                        {/if}
+                    </div>
+                    <!-- 
+                    CTA-read-more -->
+                    <a href="/">
+                        <p class='small' style='color: var(--primary); font-weight: 500;'>
+                            { data.lang.read_full_review } >
                         </p>
-                    </button>
+                    </a>
+                </div>
+                <!-- 
+                promotion-info-container -->
+                <div id='promotion-info-box'>
+                    <!-- 
+                    validation-row-further-info -->
+                    <div class='column' style='margin-right: calc(100vw / 12.5901639344);'>
+                        {#if data.cashout}
+                            <div class='row check-box'>
+                                <img
+                                    src='./static/BetArena - Working/icon/􀁣.svg'
+                                    alt=''
+                                    class='checkmark'
+                                />
+                                <p class='small' style='white-space: nowrap;'>{ data.lang.cashout }</p>
+                            </div>
+                        {:else}
+                            <div/>
+                        {/if}
+                        {#if data.live_stream}
+                            <div class='row check-box'>
+                                <img
+                                    src='./static/BetArena - Working/icon/􀁣.svg'
+                                    alt=''
+                                    class='checkmark'
+                                />
+                                <p class='small' style='white-space: nowrap;'>{ data.lang.live_stream }</p>
+                            </div>
+                        {:else}
+                            <div/>
+                        {/if}
+                        {#if data.bet_builder}
+                            <div class='row check-box'>
+                                <img
+                                    src='./static/BetArena - Working/icon/􀁣.svg'
+                                    alt=''
+                                    class='checkmark'
+                                />
+                                <p class='small' style='white-space: nowrap;'>{ data.lang.bet_builder }</p>
+                            </div>
+                        {:else}
+                            <div/>
+                        {/if}
+                    </div>
+                    <!-- 
+                    disclaimer-info-&-button -->
+                    <div class='row'>
+                        <p class='small' style='margin-right: calc(100vw / 48); text-align: end;'>
+                            { data.lang.disclaimer }
+                        </p>
+                        <button class='btn-primary'>
+                            <p class='medium' style='white-space: nowrap;'>
+                                Get 500$ bonus
+                            </p>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-    
+    {/if}
+
 {:catch error}
     <p style="color: red">{error.message}</p>
 {/await}

--- a/src/models/content-loader-interface.ts
+++ b/src/models/content-loader-interface.ts
@@ -1,0 +1,30 @@
+/**
+ * THis is the ContentLoader
+ * INTERFACE
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Documentation:
+ * https://github.com/PaulMaly/svelte-content-loader?ref=madewithsvelte.com
+ * 
+ * How it works? Example;
+ * https://github.com/PaulMaly/svelte-content-loader/blob/master/src/ContentLoader.svelte 
+*/
+
+
+/**
+ * ContentLoaderProps
+ * INTERFACE 
+*/
+export interface ContentLoaderProps {
+    width?: number | string	    // Default - 400	
+    height?: number | string	// Default - 130	
+    speed?: number	            // Default - 2	
+    preserveAspectRatio?: string	// Default - 'xMidYMid meet'	
+    primaryColor?: string	        // Default '#f9f9f9'	
+    secondaryColor?: string	        // Default - '#ecebeb'	
+    uniqueKey?: string	            // randomId() Unique ID, you need to make it consistent for SSR
+    animate?: boolean	            // DEfault - true	
+    baseUrl?: string	            // empty string	- Required if you're using in your . Defaults to an empty string.
+                                    // This prop is common used as: which will fill the SVG attribute with the relative path.
+    primaryOpacity?: number	        // Deafult - 1 Background opacity (0 = transparent, 1 = opaque) used to solve an issue in Safari
+    secondaryOpacity?: number	    // Default - 1 Background opacity (0 = transparent, 1 = opaque) used to solve an issue in Safari
+}


### PR DESCRIPTION
+ closes #4 

Added a content loading placeholder to the widgets on both tablet / desktop and mobile.

You may need to do `npm install svelte-content-loader` first as it appears not to have been included in the `package.json` in this `pull-request`.